### PR TITLE
Right justify the translation notes

### DIFF
--- a/_layouts/default-en.html
+++ b/_layouts/default-en.html
@@ -15,6 +15,6 @@
             <h1 id="page-title">{{ page.title }}</h1>
             {{ content }}
         </section>
-        <aside>This page uses <a href="https://translate.google.co.jp/" target="_blank">Google Translate</a> and <a href="https://www.deepl.com/translator" target="_blank">DeepL Translate</a>.</aside>
+        <aside id="trans">This page uses <a href="https://translate.google.co.jp/" target="_blank">Google Translate</a> and <a href="https://www.deepl.com/translator" target="_blank">DeepL Translate</a>.</aside>
     </body>
 </html>

--- a/css/style.css
+++ b/css/style.css
@@ -14,3 +14,7 @@ h1#site-title a {
 h1#page-title {
     font-size: 4em;
 }
+
+aside#trans {
+    text-align: right;
+}


### PR DESCRIPTION
Close #9 .
# 内容
asideタグを右寄せにする
# 理由
本来の文章と混じってしまうから
# 影響
Add trans ID to aside of default-en.html
Set aside#trans to right-aligned