### PR TITLE
Fix syntax error in replace_first

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-{% assign lang = page.url | replace_first:"/" "" | split:"/" | first %}
+{% assign lang = page.url | replace_first:"/" , "" | split:"/" | first %}
 
 {% capture title %}
 {% if lang == 'ja' %}{{ site.title.ja }}


### PR DESCRIPTION
Close #28  .
# 内容
replace_firstの1つ目の引数と2つ目の引数の間に,を追加
# 理由
放置しておいたら予期せぬエラーが起こりそうで怖いから
# 影響
Fix syntax error in replace_first